### PR TITLE
11.1 list generators implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,41 @@ from src.masks import masks
 masked_card = masks.get_mask_card_number("7000792289606361")  # "7000 79** **** 6361"
 masked_account = masks.get_mask_account("73654108430135874305")  # "**4305"
 ```
+
+## Модуль `generators`
+
+Модуль содержит генераторы для работы с транзакциями и номерами карт.
+
+### Функции
+
+#### `filter_by_currency(transactions, currency)`
+Фильтрует транзакции по заданной валюте и возвращает итератор.
+
+**Пример использования:**
+```python
+usd_transactions = filter_by_currency(transactions, "USD")
+for _ in range(2):
+    print(next(usd_transactions))
+
+
+### 4. Проверим покрытие тестами
+
+Запустим тесты с проверкой покрытия:
+
+```bash
+pytest --cov=generators --cov-report=html
+
+## Модуль generators
+
+Реализует генераторы для работы с банковскими транзакциями.
+
+### Функции
+
+#### `filter_by_currency(transactions, currency)`
+Фильтрует транзакции по валюте.
+
+Пример:
+```python
+usd_transactions = filter_by_currency(transactions, "USD")
+for transaction in usd_transactions:
+    print(transaction)

--- a/src/generators.py
+++ b/src/generators.py
@@ -1,0 +1,67 @@
+from typing import Iterator, List, TypedDict
+
+
+class Currency(TypedDict):
+    name: str
+    code: str
+
+
+class OperationAmount(TypedDict):
+    amount: str
+    currency: Currency
+
+
+class Transaction(TypedDict):
+    id: int
+    state: str
+    date: str
+    operationAmount: OperationAmount
+    description: str
+    from_: str  # Используем from_ вместо from (ключевое слово)
+    to: str
+
+
+def filter_by_currency(transactions: List[Transaction], currency: str) -> Iterator[Transaction]:
+    """
+    Фильтрует транзакции по заданной валюте и возвращает итератор.
+
+    Args:
+        transactions: Список транзакций
+        currency: Код валюты (например "USD")
+
+    Yields:
+        Транзакции с указанной валютой
+    """
+    for transaction in transactions:
+        if transaction['operationAmount']['currency']['code'] == currency:
+            yield transaction
+
+
+def transaction_descriptions(transactions: List[Transaction]) -> Iterator[str]:
+    """
+    Генератор описаний транзакций.
+
+    Args:
+        transactions: Список транзакций
+
+    Yields:
+        Описание каждой транзакции
+    """
+    for transaction in transactions:
+        yield transaction['description']
+
+
+def card_number_generator(start: int, end: int) -> Iterator[str]:
+    """
+    Генератор номеров банковских карт.
+
+    Args:
+        start: Начальный номер
+        end: Конечный номер (включительно)
+
+    Yields:
+        Номера карт в формате "XXXX XXXX XXXX XXXX"
+    """
+    for number in range(start, end + 1):
+        num_str = f"{number:016d}"
+        yield f"{num_str[:4]} {num_str[4:8]} {num_str[8:12]} {num_str[12:16]}"

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1,0 +1,86 @@
+import pytest
+from src.generators import (
+    filter_by_currency,
+    transaction_descriptions,
+    card_number_generator
+)
+
+
+@pytest.fixture
+def sample_transactions() -> list[dict]:
+    return [
+        {
+            "id": 939719570,
+            "state": "EXECUTED",
+            "date": "2018-06-30T02:08:58.425572",
+            "operationAmount": {
+                "amount": "9824.07",
+                "currency": {"name": "USD", "code": "USD"}
+            },
+            "description": "Перевод организации",
+            "from_": "Счет 75106830613657916952",
+            "to": "Счет 11776614605963066702"
+        },
+        {
+            "id": 142264268,
+            "state": "EXECUTED",
+            "date": "2019-04-04T23:20:05.206878",
+            "operationAmount": {
+                "amount": "79114.93",
+                "currency": {"name": "USD", "code": "USD"}
+            },
+            "description": "Перевод со счета на счет",
+            "from_": "Счет 19708645243227258542",
+            "to": "Счет 75651667383060284188"
+        },
+        {
+            "id": 873106923,
+            "state": "EXECUTED",
+            "date": "2019-03-23T01:09:46.296404",
+            "operationAmount": {
+                "amount": "43318.34",
+                "currency": {"name": "руб.", "code": "RUB"}
+            },
+            "description": "Перевод со счета на счет",
+            "from_": "Счет 44812258784861134719",
+            "to": "Счет 74489636417521191160"
+        }
+    ]
+
+
+@pytest.mark.parametrize("currency,expected_count", [
+    ("USD", 2),
+    ("RUB", 1),
+    ("EUR", 0)
+])
+def test_filter_by_currency(sample_transactions, currency, expected_count):
+    result = list(filter_by_currency(sample_transactions, currency))
+    assert len(result) == expected_count
+    for transaction in result:
+        assert transaction['operationAmount']['currency']['code'] == currency
+
+
+def test_transaction_descriptions(sample_transactions):
+    descriptions = list(transaction_descriptions(sample_transactions))
+    assert descriptions == [
+        "Перевод организации",
+        "Перевод со счета на счет",
+        "Перевод со счета на счет"
+    ]
+
+
+@pytest.mark.parametrize("start,end,expected", [
+    (1, 3, [
+        "0000 0000 0000 0001",
+        "0000 0000 0000 0002",
+        "0000 0000 0000 0003"
+    ]),
+    (9999, 10001, [
+        "0000 0000 0000 9999",
+        "0000 0000 0001 0000",
+        "0000 0000 0001 0001"
+    ])
+])
+def test_card_number_generator(start, end, expected):
+    result = list(card_number_generator(start, end))
+    assert result == expected


### PR DESCRIPTION
 Что сделано  
 Реализованы генераторы:  
- `filter_by_currency()` — фильтрация транзакций по валюте  
- `transaction_descriptions()` — генератор описаний транзакций  
- `card_number_generator()` — генератор номеров карт  

 Написаны тесты с фикстурами и параметризацией (покрытие >80%)  
 Добавлена документация в `README.md`  
 Прошли проверки: `flake8`, `mypy`, `pytest`  

 Как проверить  
1. Запустить тесты:  
   ```bash
   pytest tests/test_generators.py --cov=src
